### PR TITLE
Comparisons bugfix

### DIFF
--- a/Scripts/modules/Comparisons.nf
+++ b/Scripts/modules/Comparisons.nf
@@ -19,7 +19,7 @@ process COMPARISONS {
 	
 	source activate TaxProfiler
 
-	python /medstore/Development/Metagenomics/TaxProfiler/Taxprofiler-Metagenomics/Scripts/ParserScripts/runComparison.py  --Parsed_Taxprofiler_out "$launchDir/${params.OutputDir}/Taxprofiler_Parsed" --Metadata ${Metadata_c}
+	python /medstore/Development/Metagenomics/TaxProfiler/Taxprofiler-Metagenomics/Scripts/ParserScripts/runComparison.py  --Tools ${Diamond_outs} ${Kraken2_outs} ${KrakenUniq_outs} --Metadata ${Metadata_c}
 
 	"""		
 }

--- a/Scripts/modules/ParseDiamond.nf
+++ b/Scripts/modules/ParseDiamond.nf
@@ -13,6 +13,9 @@ process PARSEDIAMOND {
 		
 	output:
 		path 'Diamond', emit: Diamond_outs
+		path 'Diamond/*_CountsForplotting.txt', emit: Diamond_outs_countfiles
+                path 'Diamond/Extras/*_SpeciesDomainLinkage.txt', emit: Diamond_outs_linkagefiles
+
 
 	script:
 	if (params.IgnoreReadExtraction_Diamond)

--- a/Scripts/modules/ParseKraken2.nf
+++ b/Scripts/modules/ParseKraken2.nf
@@ -11,6 +11,8 @@ process PARSEKRAKEN2 {
 		
 	output:
 		path 'Kraken2', emit: Kraken2_outs
+		path 'Kraken2/*_CountsForplotting.txt', emit: Kraken2_outs_countfiles
+		path 'Kraken2/Extras/*_SpeciesDomainLinkage.txt', emit: Kraken2_outs_linkagefiles
 
 	script:
 	if (params.IgnoreReadExtraction_kraken2)

--- a/misc/Test_Illumina/runMain.sh
+++ b/misc/Test_Illumina/runMain.sh
@@ -18,8 +18,4 @@ outDir=TaxProfiler_out
 Metadata=/medstore/Development/Metagenomics/TaxProfiler/Taxprofiler-Metagenomics/misc/Test_Illumina/Metadata.csv
 Config=/medstore/Development/Metagenomics/TaxProfiler/Taxprofiler-Metagenomics/configs/Mandalore_Taxprofiler_mod.config
 
-
 nextflow run /medstore/Development/Metagenomics/TaxProfiler/Taxprofiler-Metagenomics/Scripts/main.nf --OutputDir $outDir --SampleSheet $SampleSheet -c $Config --IgnoreReadExtraction_krakenuniq --Metadata $Metadata
-
-
-


### PR DESCRIPTION
There was a bug where classifiers randomly were not added correctly to the excel sheet, they were missing the count values. The issue was that that we were pointing the input to the comparison script to the final outputfolder of the parser. Larger runs did not have time to finish the copying to the taxprofiler out. Now it takes the output from the tool folders, using the same method in write excel. This results in the possibility to take the outputs from the tmp folders instead. 